### PR TITLE
Use System.Timers.Timer instead of System.Threading.Timers

### DIFF
--- a/Tortuga.Anchor/Tortuga.Anchor.source/shared/TaskUtilities.cs
+++ b/Tortuga.Anchor/Tortuga.Anchor.source/shared/TaskUtilities.cs
@@ -39,12 +39,14 @@ namespace Tortuga.Anchor
                 throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
 
             var tcs = new TaskCompletionSource<object>();
-            Timer t = null; //What prevents this timer from being prematurely garbage collected?
-            t = new Timer(state =>
+            var t = new System.Timers.Timer(delay.TotalMilliseconds);
+            t.AutoReset = false;
+            t.Elapsed += (source, e) =>
             {
                 t.Dispose();
                 tcs.SetCanceled();
-            }, null, delay, TimeSpan.FromMilliseconds(int.MaxValue));
+            };
+            t.Start();
             return tcs.Task;
         }
 
@@ -72,12 +74,14 @@ namespace Tortuga.Anchor
                 throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
 
             var tcs = new TaskCompletionSource<object>();
-            Timer t = null; //What prevents this timer from being prematurely garbage collected?
-            t = new Timer(state =>
+            var t = new System.Timers.Timer(delay);
+            t.AutoReset = false;
+            t.Elapsed += (source, e) =>
             {
                 t.Dispose();
                 tcs.SetCanceled();
-            }, null, delay, int.MaxValue);
+            };
+            t.Start();
             return tcs.Task;
         }
 
@@ -105,12 +109,14 @@ namespace Tortuga.Anchor
                 throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
 
             var tcs = new TaskCompletionSource<T>();
-            Timer t = null; //What prevents this timer from being prematurely garbage collected?
-            t = new Timer(state =>
+            var t = new System.Timers.Timer(delay.TotalMilliseconds);
+            t.AutoReset = false;
+            t.Elapsed += (source, e) =>
             {
                 t.Dispose();
                 tcs.SetResult(result);
-            }, null, delay, TimeSpan.FromMilliseconds(int.MaxValue));
+            };
+            t.Start();
             return tcs.Task;
         }
 
@@ -129,12 +135,14 @@ namespace Tortuga.Anchor
                 throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
 
             var tcs = new TaskCompletionSource<T>();
-            Timer t = null; //What prevents this timer from being prematurely garbage collected?
-            t = new Timer(state =>
+            var t = new System.Timers.Timer(delay);
+            t.AutoReset = false;
+            t.Elapsed += (source, e) =>
             {
                 t.Dispose();
                 tcs.SetResult(result);
-            }, null, delay, int.MaxValue);
+            };
+            t.Start();
             return tcs.Task;
         }
 

--- a/Tortuga.Anchor/Tortuga.Anchor.source/shared/TaskUtilities.cs
+++ b/Tortuga.Anchor/Tortuga.Anchor.source/shared/TaskUtilities.cs
@@ -70,19 +70,7 @@ namespace Tortuga.Anchor
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
         public static Task AutoCancelingTask<T>(int delay)
         {
-            if (delay < 0)
-                throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
-
-            var tcs = new TaskCompletionSource<object>();
-            var t = new System.Timers.Timer(delay);
-            t.AutoReset = false;
-            t.Elapsed += (source, e) =>
-            {
-                t.Dispose();
-                tcs.SetCanceled();
-            };
-            t.Start();
-            return tcs.Task;
+            return AutoCancelingTask<T>(TimeSpan.FromMilliseconds(delay));
         }
 
         /// <summary>
@@ -131,19 +119,7 @@ namespace Tortuga.Anchor
         [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "AutoCompleting")]
         public static Task<T> AutoCompletingTask<T>(T result, int delay)
         {
-            if (delay < 0)
-                throw new ArgumentOutOfRangeException(nameof(delay), delay, $"{nameof(delay)} cannot be less than 0");
-
-            var tcs = new TaskCompletionSource<T>();
-            var t = new System.Timers.Timer(delay);
-            t.AutoReset = false;
-            t.Elapsed += (source, e) =>
-            {
-                t.Dispose();
-                tcs.SetResult(result);
-            };
-            t.Start();
-            return tcs.Task;
+            return AutoCompletingTask(result, TimeSpan.FromMilliseconds(delay));
         }
 
 #endif


### PR DESCRIPTION
Fixes #20 
The second commit also removes some duplicated code.

PS: I noticed that the generic functions of AutoCancelingTask and AutoCompletingTask never use their generic parameter. Is that intentional? What purpose do they serve?